### PR TITLE
Merge share skipfiletypes

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Share.tuning.page
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Share.tuning.page
@@ -196,7 +196,7 @@ _(Skip file types)_:
   </select>
 
 <!--:mover_tuning_file_type_help:-->
-> Select **Yes** to skip specific file types.
+> Select **Yes** to skip specific file types in addition to those selected globally.
 
 _(Comma seperated list of file types)_:
 : <input type='text' name='filetypesv' class='myfiletypesf' value='<?= $cfg['filetypesv'] ?>' <?= $filetypesfDisabled ?>>

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -612,6 +612,7 @@ start() {
 
     for SHARECFG in /boot/config/shares/*; do
         overrideFlag=0
+        globalSkipFileTypes=$SKIPFILETYPES
 
         if grep -qs 'shareUseCache="yes"' "$SHARECFG"; then
             #Start Creating the Find String.
@@ -733,6 +734,13 @@ start() {
                     done
                 fi
 
+                if [ $overrideFlag = 1 ] && [ -n "$globalSkipFileTypes" ]; then
+                    FINDSTR+=" | grep -iv"
+                    for i in $(echo $globalSkipFileTypes | sed "s/,/ /g"); do
+                        FINDSTR+=" -e '\\$i'"
+                    done
+                fi
+                
                 if [ -d "$SHAREPATH" ]; then
                     eval "$FINDSTR>>$MOVER_FILELIST"
                 fi


### PR DESCRIPTION
This pull request corrects what I saw as an inconsistency in the global/per-share settings. 

Under Settings -> Scheduler -> Mover Tuning w/Age - Days Old
* The "Ignore File Types" option correctly omits file when the mover is run with a global config.

Under Shares -> [Share Name] -> Mover Tuning - Share Settings
* With the "Override Mover Tuning settings for this share" enabled
* The "Skip file types" option is independent of the global config i.e. if a file type was excluded globally but not at the share-level it would remain.

The change can be summarized as checking whether a share specific config was enabled, and if so adding another inverse grep stage to the FINDSTR.

Note: Have not had the opportunity to test, though the diff is fairly easy to understand.